### PR TITLE
Update admin API endpoints

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -31,8 +31,8 @@ export default function AdminPage() {
       console.log('Fetching admin stats...');
       try {
         const [restaurantsRes, usersRes] = await Promise.all([
-          apiGet('/auth/restaurants'),
-          apiGet('/auth/users')
+          apiGet('/restaurants'),
+          apiGet('/users')
         ])
         console.log('Restaurants API response:', restaurantsRes);
         console.log('Users API response:', usersRes);

--- a/frontend/src/app/admin/wine-lists/page.tsx
+++ b/frontend/src/app/admin/wine-lists/page.tsx
@@ -88,7 +88,7 @@ export default function AdminWineLists() {
     try {
       const sessionToken = (session as any)?.accessToken
       await axios.post(
-        'http://127.0.0.1:8000/api/auth/wine-lists/upload',
+        'http://127.0.0.1:8000/api/wine-lists/upload',
         formData,
         {
           headers: {


### PR DESCRIPTION
## Summary
- query restaurants & users without `/auth` on admin dashboard
- upload wine lists through `/wine-lists/upload`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a13033b88323ae16050374c6766a