### PR TITLE
Parametrize API base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Thumbs.db
 # VSCode/Cursor
 .vscode
 .idea
+
+/frontend/.env.local

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -2,6 +2,8 @@ import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import axios from "axios";
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE;
+
 export default NextAuth({
   providers: [
     CredentialsProvider({
@@ -13,7 +15,7 @@ export default NextAuth({
       async authorize(credentials) {
         try {
           const res = await axios.post(
-            "http://127.0.0.1:8000/api/auth/login",
+            `${API_BASE}/auth/login`,
             {
               email: credentials.email,
               password: credentials.password
@@ -54,7 +56,7 @@ export default NextAuth({
         if (Date.now() >= tokenExp - 5 * 60 * 1000) { // Refresh 5 minutes before expiry
           try {
             const res = await axios.post(
-              "http://127.0.0.1:8000/api/auth/refresh",
+              `${API_BASE}/auth/refresh`,
               { refresh_token: token.refreshToken },
               { headers: { "Content-Type": "application/json" } }
             );

--- a/frontend/src/app/admin/wine-lists/page.tsx
+++ b/frontend/src/app/admin/wine-lists/page.tsx
@@ -11,6 +11,8 @@ import { Select } from '@/components/ui/select'
 import axios from 'axios'
 import ClientLayout from '../../client-layout'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE
+
 interface Restaurant {
   id: string;
   name: string;
@@ -88,7 +90,7 @@ export default function AdminWineLists() {
     try {
       const sessionToken = (session as any)?.accessToken
       await axios.post(
-        'http://127.0.0.1:8000/api/wine-lists/upload',
+        `${API_BASE}/wine-lists/upload`,
         formData,
         {
           headers: {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -5,6 +5,8 @@ import axios from 'axios'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE
+
 export default function Register() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -21,7 +23,7 @@ export default function Register() {
     setSuccess(false)
     setLoading(true)
     try {
-      await axios.post('http://127.0.0.1:8000/api/auth/register', {
+      await axios.post(`${API_BASE}/auth/register`, {
         email,
         password,
         name

--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { getSession } from "next-auth/react";
 
-const API_BASE = "http://127.0.0.1:8000/api";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE;
 
 async function getAuthHeaders() {
   const session = await getSession();


### PR DESCRIPTION
## Summary
- ignore local env config
- load API base url from NEXT_PUBLIC_API_BASE in utils
- use API_BASE when logging in or refreshing tokens
- use API_BASE when registering users
- use API_BASE when uploading wine lists

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1eddff08323b465a9a919ab9d74